### PR TITLE
Update hash algorithms for SNMPv3 to match RFC

### DIFF
--- a/pysnmp_apps/cli/secmod.py
+++ b/pysnmp_apps/cli/secmod.py
@@ -13,9 +13,9 @@ authProtocols = {
     'MD5': config.usmHMACMD5AuthProtocol,
     'SHA': config.usmHMACSHAAuthProtocol,
     'SHA96': config.usmHMACSHAAuthProtocol,
-    'SHA128': config.usmHMAC128SHA224AuthProtocol,
-    'SHA192': config.usmHMAC192SHA256AuthProtocol,
-    'SHA256': config.usmHMAC256SHA384AuthProtocol,
+    'SHA224': config.usmHMAC128SHA224AuthProtocol,
+    'SHA256': config.usmHMAC192SHA256AuthProtocol,
+    'SHA384': config.usmHMAC256SHA384AuthProtocol,
     'SHA512': config.usmHMAC384SHA512AuthProtocol,
     'NONE': config.usmNoAuthProtocol
 }


### PR DESCRIPTION
RFC 7630 section 4 lists the 4 advanced authentication methods.  Some of the names used currently are a for the truncated size sent rather than the hash algorithm used.  I changed the incorrect ones to use the correct naming scheme.