### PR TITLE
Unified SNMP crypto algorithm IDs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ python:
 # temporary broken
 #  - "pypy3"
 install:
+  - pip install codecov
   - pip install -r requirements.txt
-  - python setup.py install
+  - pip install -e .
 script:
   - sh runtests.sh

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,10 @@
 
+Revision 0.5.2, released 18-12-2017
+-----------------------------------
+
+- Fixed SNMP crypto algorithm identifiers to be named consistently after
+  key length rather than MAC length
+
 Revision 0.5.1, released 21-11-2017
 -----------------------------------
 

--- a/pysnmp_apps/__init__.py
+++ b/pysnmp_apps/__init__.py
@@ -1,2 +1,2 @@
 # http://www.python.org/dev/peps/pep-0396/
-__version__ = '0.5.1'
+__version__ = '0.5.2'

--- a/pysnmp_apps/cli/secmod.py
+++ b/pysnmp_apps/cli/secmod.py
@@ -12,10 +12,9 @@ from pysnmp import error
 authProtocols = {
     'MD5': config.usmHMACMD5AuthProtocol,
     'SHA': config.usmHMACSHAAuthProtocol,
-    'SHA96': config.usmHMACSHAAuthProtocol,
-    'SHA128': config.usmHMAC128SHA224AuthProtocol,
-    'SHA192': config.usmHMAC192SHA256AuthProtocol,
-    'SHA256': config.usmHMAC256SHA384AuthProtocol,
+    'SHA224': config.usmHMAC128SHA224AuthProtocol,
+    'SHA256': config.usmHMAC192SHA256AuthProtocol,
+    'SHA384': config.usmHMAC256SHA384AuthProtocol,
     'SHA512': config.usmHMAC384SHA512AuthProtocol,
     'NONE': config.usmNoAuthProtocol
 }
@@ -38,15 +37,16 @@ SNMPv1/v2c security options:
 SNMPv3 security options:
    -u SECURITY-NAME      SNMP USM user security name (e.g. bert)
    -l SECURITY-LEVEL     security level (noAuthNoPriv|authNoPriv|authPriv)
-   -a AUTH-PROTOCOL      authentication protocol (%s)
+   -a AUTH-PROTOCOL      authentication protocol ID (%s)
    -A PASSPHRASE         authentication protocol pass phrase (8+ chars)
-   -x PRIV-PROTOCOL      privacey protocol (%s)
+   -x PRIV-PROTOCOL      privacy protocol ID (%s)
    -X PASSPHRASE         privacy protocol pass phrase (8+ chars)
    -E CONTEXT-ENGINE-ID  context engine ID (e.g. 800000020109840301)
    -e ENGINE-ID          security SNMP engine ID (e.g. 800000020109840301)
    -n CONTEXT-NAME       SNMP context name (e.g. bridge1)
    -Z BOOTS,TIME         destination SNMP engine boots/time
-""" % ('|'.join(sorted(authProtocols)), '|'.join(sorted(privProtocols)))
+""" % ('|'.join(sorted([x for x in authProtocols if x != 'NONE'])),
+       '|'.join(sorted([x for x in privProtocols if x != 'NONE'])))
 
 # Scanner
 


### PR DESCRIPTION
This PR renames some inconsistently named SNMP crypto algorithms ID. The new uniform schema is to name IDs after the length of the hash key.

See also https://github.com/etingof/pysnmp/issues/116